### PR TITLE
bootstrapをGemfileに導入

### DIFF
--- a/web/Gemfile
+++ b/web/Gemfile
@@ -64,3 +64,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'bootstrap','~>4.1.1'
+gem 'jquery-rails'
+gem 'mini_racer'

--- a/web/Gemfile.lock
+++ b/web/Gemfile.lock
@@ -47,9 +47,15 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    autoprefixer-rails (9.1.4)
+      execjs
     bindex (0.5.0)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
+    bootstrap (4.1.3)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.8.0)
@@ -84,6 +90,11 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
+    libv8 (6.7.288.46.1-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -99,6 +110,8 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
+    mini_racer (0.2.3)
+      libv8 (>= 6.3)
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
@@ -106,6 +119,7 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     pg (0.20.0)
+    popper_js (1.14.3)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
@@ -194,12 +208,15 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap (~> 4.1.1)
   byebug
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
+  mini_racer
   pg (= 0.20.0)
   puma (~> 3.11)
   rails (~> 5.2.1)

--- a/web/app/assets/javascripts/application.js
+++ b/web/app/assets/javascripts/application.js
@@ -14,3 +14,6 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets

--- a/web/app/assets/stylesheets/application.scss
+++ b/web/app/assets/stylesheets/application.scss
@@ -10,6 +10,8 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require_self
+ //* require_tree .
+ //* require_self
  */
+//@import "botstrap-sprockets";
+@import "bootstrap";

--- a/web/app/views/user_profile/home.html.erb
+++ b/web/app/views/user_profile/home.html.erb
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <title>プロトタイプ</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link href="https://fonts.googleapis.com/css?family=Amatic+SC:700" rel="stylesheet">
 </head>


### PR DESCRIPTION
# bootstrap4.1.3をGemfileで導入できるようにしました。
同時にUser_profile/home.html.erbのbootstrapを呼び出す記述を削除しました。

## 変更点
### Gemfile
- bootstrap,jqueryを呼び出す記述
- その他の依存関係を解決するmini_racerの導入
### application.js
- jquery関係の記述を追加
### application.css
- ファイルの拡張子をscssに変更
- bootstrapの読み込み
### user_profile/home.html.erb
- bootstrapを呼び出す記述の削除