### PR TITLE
ユーザー登録用フォームへのリンクを追加

### DIFF
--- a/web/app/views/top/index.html.erb
+++ b/web/app/views/top/index.html.erb
@@ -2,8 +2,8 @@
 <h2>説明</h2>
 <p>どんな趣味も共有できる、心の壁も取り払うことができる</p>
 <h2>最近更新したユーザー</h2>
-<%=link_to 'KAME',{ :controller => "user_profile", :action => "kame" },{ :class => "btn btn-primary" }%>
-<%=link_to 'RYAMA',{ :controller => "user_profile", :action => "ryama" },{ :class => "btn btn-primary" }%>
-<%=link_to 'GUSSY',{ :controller => "user_profile", :action => "gussy" },{ :class => "btn btn-primary" }%>
+<%=link_to 'KAME',{ :controller => "user_profile", :action => "kame" },{ :class => "btn btn-outline-primary" }%>
+<%=link_to 'RYAMA',{ :controller => "user_profile", :action => "ryama" },{ :class => "btn btn-outline-primary" }%>
+<%=link_to 'GUSSY',{ :controller => "user_profile", :action => "gussy" },{ :class => "btn btn-outline-primary" }%>
 <h2>ユーザー登録</h2>
-<button disabled>新規登録</button>
+<%=link_to 'Start hobicom!',"https://goo.gl/forms/fTk0pecag02QIjQS2",{ :class => "btn btn-primary" }%>

--- a/web/app/views/top/index.html.erb
+++ b/web/app/views/top/index.html.erb
@@ -6,4 +6,4 @@
 <%=link_to 'RYAMA',{ :controller => "user_profile", :action => "ryama" },{ :class => "btn btn-outline-primary" }%>
 <%=link_to 'GUSSY',{ :controller => "user_profile", :action => "gussy" },{ :class => "btn btn-outline-primary" }%>
 <h2>ユーザー登録</h2>
-<%=link_to 'Start hobicom!',"https://goo.gl/forms/fTk0pecag02QIjQS2",{ :class => "btn btn-primary" }%>
+<%=link_to 'Start ホビコム!',"https://goo.gl/forms/fTk0pecag02QIjQS2",{ :class => "btn btn-primary" }%>


### PR DESCRIPTION
# 今回の変更点
- 登録用ボタンの有効化
- 登録用ボタンからリンク
- 他のユーザーのページを見るためのボタンのデザイン変更
## 登録用ボタンの有効化
- 登録用ボタンをlink_toを使って生成
- bootstrap buttonコンポーネントを利用
## 登録用ボタンからのリンク
- 登録用ボタンからユーザー登録用フォームへリンクを作成
## 他のユーザーのページを見るためのボタンのデザイン変更
- 他のユーザーのページを見るためのボタンをoutline化