### PR TITLE
homeを押した後のコピーするURLの修正

### DIFF
--- a/web/app/views/user_profile/show.html.erb
+++ b/web/app/views/user_profile/show.html.erb
@@ -82,12 +82,14 @@
         <textarea id="txt_share" style="width:450px; height:100px;"></textarea>
         <button class="btn" id="cp" data-clipboard-action="copy" data-clipboard-target="#txt_share">リンクをコピー</button>
         <script type="application/javascript">
-          var link=location.href;
-          var messege="私はこんな趣味を持ってるよ！ "+link+" あなたもホビコムで大事な趣味を共有しよう!!";
-          document.getElementById('txt_share').value=messege;
-          var clipboard = new Clipboard('#cp');
-          clipboard.on('success', function(e) {
-              e.clearSelection();
+          $(document).on('turbolinks:load',function(){
+              var link=document.URL;
+              var messege="私はこんな趣味を持ってるよ！ "+link+" あなたもホビコムで大事な趣味を共有しよう!!";
+              document.getElementById('txt_share').value=messege;
+              var clipboard = new Clipboard('#cp');
+              clipboard.on('success', function(e) {
+                e.clearSelection();
+                });
           });
         </script>
       </div>


### PR DESCRIPTION
# 今回の変更点
- show.html.erbのjsコードの修正
# 今回の変更点の詳細
## show.html.erb
- turbolinks対策の実施
  - jqueryを用いた実行に変更
  - turbolinks:onloadを適用
    - 読み込み完了後のURL取得に対応