### PR TITLE
コピー機能の排除

### DIFF
--- a/web/app/assets/javascripts/sharing.js
+++ b/web/app/assets/javascripts/sharing.js
@@ -1,16 +1,11 @@
 $(document).on('turbolinks:load',
 function create_link(){
   var link=document.URL;
-  document.getElementById('txt_share').value=link;
-  var clipboard = new Clipboard('#cp');
-  clipboard.on('success', function(e) {
-    e.clearSelection();
-    });
-    $('#code').empty();
-    $('#code').qrcode({
-      width: 100,
-      height: 100,
-      text: link
-    });
-    $('canvas').attr('id', 'code');
+  $('#code').empty();
+  $('#code').qrcode({
+    width: 100,
+    height: 100,
+    text: link
+  });
+  $('canvas').attr('id', 'code');
 });

--- a/web/app/views/user_profile/show.html.erb
+++ b/web/app/views/user_profile/show.html.erb
@@ -113,9 +113,6 @@
       <% if logged_in? and @user == current_user%>
         <div class="share_mypage">
           <h4>あなたの趣味を共有しよう</h4>
-          <h5>あなたのページのURL</h5>
-          <textarea id="txt_share" style="width:450px; height:100px;"></textarea>
-          <button class="btn" id="cp" data-clipboard-action="copy" data-clipboard-target="#txt_share">リンクをコピー</button>
           <h5>あなたのページのQRコード</h5>
           <div class="qr-area" id="code">
           </div>


### PR DESCRIPTION
# 今回の変更点
- リンクコピー機能の排除

# 今回の変更点の詳細
## view/user_proflie/show.html.erb
- リンクを入力していたテキストボックスを削除
- リンクをコピーするボタンの削除

## asset/javascripts/sharing.js
- clipboardjsを呼び出す部分の削除  

## ~~asset/javascripts/jquery.qrcode.min.js~~
- ~~使用しないためファイルを削除~~