### PR TITLE
一覧画面の付箋サイズを相対指定に変更

### DIFF
--- a/web/app/assets/stylesheets/show.scss
+++ b/web/app/assets/stylesheets/show.scss
@@ -163,7 +163,14 @@ ol.sample1{
   -webkit-box-shadow: 0 0 40px rgba(0, 0, 0, 0.2) inset,0 0 4px rgba(0, 0, 0, 0.2) ;
   -moz-box-shadow: 0 0 40px rgba(0, 0, 0, 0.2) inset,0 0 4px rgba(0, 0, 0, 0.2) ;
   box-shadow: 0 0 40px rgba(0, 0, 0, 0.2) inset,0 0 4px rgba(0, 0, 0, 0.2) ;
-  width:340px;
+}
+//友人情報表示サイズ調整
+@media (min-width:768px){
+  //PCクラスのディスプレイはサイズ指定
+  ol.sample1{
+    width:21.25rem;
+  }
+  //PCより小さいディスプレイにはディスプレイフル表示
 }
 ol.sample1:after{
   content:"Hobby-com";  /* 右下の文字 */


### PR DESCRIPTION
# 今回の変更点
- フレンド一覧画面のレイアウト崩れに対応
# 今回の変更点の詳細
## assets/stylesheets/show.scss
- リスト表示時の付箋の大きさの絶対指定を削除
- PC環境での閲覧時のみサイズを相対指定を実施
- スマホ等での閲覧時には画面幅に合わせて自動調整